### PR TITLE
Add polygon as a provider to spice-provider

### DIFF
--- a/javascript/snippets/ethersjs/spice-provider.js
+++ b/javascript/snippets/ethersjs/spice-provider.js
@@ -28,6 +28,9 @@ export class SpiceProvider extends UrlJsonRpcProvider {
       case 'homestead':
         path = '/eth';
         break;
+      case 'polygon':
+        path = '/polygon';
+        break;
       default:
         logger.throwArgumentError(
           'unsupported network',

--- a/javascript/snippets/ethersjs/spice-provider.js
+++ b/javascript/snippets/ethersjs/spice-provider.js
@@ -28,7 +28,7 @@ export class SpiceProvider extends UrlJsonRpcProvider {
       case 'homestead':
         path = '/eth';
         break;
-      case 'polygon':
+      case 'matic':
         path = '/polygon';
         break;
       default:


### PR DESCRIPTION
The ethersjs docs lists `matic` as the network name for Polygon: https://docs.ethers.io/v5/api/providers/api-providers/#AlchemyProvider

<img width="672" alt="Screen Shot 2022-09-27 at 3 37 39 PM" src="https://user-images.githubusercontent.com/879445/192451157-2c6e80f9-bf2c-4092-bb44-c534e2f47d66.png">
